### PR TITLE
Lower jenkins-core dep to 1.580 and refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version>
+    <version>1.580</version>
   </parent>
 
   <artifactId>aws-credentials</artifactId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentials.java
@@ -1,0 +1,36 @@
+package com.cloudbees.jenkins.plugins.awscredentials;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+
+/**
+ * A {@link AWSCredentialsProvider} that is bound to the Jenkins {@link Credentials} api.
+ *
+ * @since 1.11
+ */
+@NameWith(value = AWSCredentials.NameProvider.class, priority = 1)
+public interface AWSCredentials extends StandardCredentials, AWSCredentialsProvider {
+    String getDisplayName();
+
+    /**
+     * Our name provider.
+     */
+    public static class NameProvider extends CredentialsNameProvider<AmazonWebServicesCredentials> {
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getName(@NonNull AmazonWebServicesCredentials c) {
+            String description = Util.fixEmptyAndTrim(c.getDescription());
+            return c.getDisplayName() + (description != null ? " (" + description + ")" : "");
+        }
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -48,7 +48,9 @@ import org.kohsuke.stapler.QueryParameter;
 
 import java.net.HttpURLConnection;
 
-public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials implements AmazonWebServicesCredentials {
+// Implement AmazonWebServicesCredentials for backward compatibility of plugins that consume AmazonWebServicesCredentials
+// And did not yet migrate to AWSCredentials
+public class AWSCredentialsImpl extends BaseAWSCredentials implements AmazonWebServicesCredentials, com.cloudbees.jenkins.plugins.awscredentials.AWSCredentials {
 
     private final String accessKey;
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/BaseAWSCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/BaseAWSCredentials.java
@@ -25,19 +25,17 @@
 
 package com.cloudbees.jenkins.plugins.awscredentials;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.cloudbees.plugins.credentials.Credentials;
-import com.cloudbees.plugins.credentials.CredentialsNameProvider;
-import com.cloudbees.plugins.credentials.NameWith;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Util;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
- * A {@link AWSCredentialsProvider} that is bound to the Jenkins {@link Credentials} api.
- *
- * @deprecated since v1.11. Use {@link AWSCredentials}
  */
-public interface AmazonWebServicesCredentials extends AWSCredentials {
-
+public abstract class BaseAWSCredentials extends BaseStandardCredentials
+        implements AWSCredentials {
+    public BaseAWSCredentials(
+            @CheckForNull CredentialsScope scope,
+            @CheckForNull String id, @CheckForNull String description) {
+        super(scope, id, description);
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/BaseAmazonWebServicesCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/BaseAmazonWebServicesCredentials.java
@@ -30,10 +30,10 @@ import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
- * @author stephenc
- * @since 08/03/2013 13:06
+ * @deprecated since 1.11. Use {@link BaseAWSCredentials}
  */
-public abstract class BaseAmazonWebServicesCredentials extends BaseStandardCredentials
+@Deprecated
+public abstract class BaseAmazonWebServicesCredentials extends BaseAWSCredentials
         implements AmazonWebServicesCredentials {
     public BaseAmazonWebServicesCredentials(
             @CheckForNull CredentialsScope scope,

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/Messages.properties
@@ -23,7 +23,7 @@
 #
 #
 
-AWSCredentialsImpl_DisplayName=Amazon Web Services Basic Credentials
+AWSCredentialsImpl_DisplayName=AWS Credentials
 AWSCredentialsImpl.SpecifyAccessKeyId=Please specify the Access Key ID
 AWSCredentialsImpl.SpecifySecretAccessKey=Please specify the Secret Access Key
 AWSCredentialsImpl.CredentialsValidWithAccessToNZones=These credentials are valid and have access to {0} availability zones


### PR DESCRIPTION
* Lower jenkins-core dependency to 1.580 instead of 1.609 to ease adoption by plugins (ec2-plugin...)
* Refactor to match AWS naming conventions: Deprecate `c.c.j.plugins.awscredentials.AmazonWebServicesCredentials` and introduce `c.c.j.plugins.awscredentials.AWSCredentials`