### PR TITLE
Remove optional on credentials-binding dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
       <version>1.7</version>
-      <optional>true</optional>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->


### PR DESCRIPTION
Remove optional on credentials-binding dependency, as is causing other plugins with transitive dependency to it to fail.

@reviewbybees