### PR TITLE
Assume Role support improvements

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -31,6 +31,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesResult;
@@ -113,6 +114,11 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
         if (StringUtils.isBlank(iamRoleArn)) {
             return initialCredentials;
         } else {
+            // Handle the case of delegation to instance profile
+            if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey.getPlainText()) ) {
+                initialCredentials = (new InstanceProfileCredentialsProvider()).getCredentials();
+            }
+
             AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn);
 
             AssumeRoleResult assumeResult = new AWSSecurityTokenServiceClient(initialCredentials).assumeRole(assumeRequest);

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -26,6 +26,9 @@
 package com.cloudbees.jenkins.plugins.awscredentials;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -54,6 +57,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     public final static String DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME = "AWS_ACCESS_KEY_ID";
     private final static String DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME = "AWS_SECRET_ACCESS_KEY";
+    private final static String SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
 
     @NonNull
     private final String accessKeyVariable;
@@ -94,6 +98,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         Map<String,String> m = new HashMap<String,String>();
         m.put(accessKeyVariable, credentials.getAWSAccessKeyId());
         m.put(secretKeyVariable, credentials.getAWSSecretKey());
+
+        // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
+        if(credentials instanceof AWSSessionCredentials) {
+            m.put(SESSION_TOKEN_VARIABLE_NAME, ((AWSSessionCredentials) credentials).getSessionToken());
+        }
         return new MultiEnvironment(m);
     }
 


### PR DESCRIPTION
Two changes in this PR.

### 1. Session Token variable
To use e.g AWS CLI with AssumeRole support, an `AWS_SESSION_TOKEN` variable must be set, or AWS would complain that no access key is found on record. This variable is only bound if credentials returned by the credentials provider are session-based.
Fixes #19  

### 2. Instance Profile credentials
To further support moving away from hard-set AWS Credentials and allow role switching (e.g cross-account access), this PR also adds following behavior:
 If no access & secret keys are set as part of credentials, but IAM role *is* set -  attempting to fetch credentials via instance profile.
Fixes #18 #15 

Motivation for both changes is to simplify management of multi-AWS account environments and to remove useage of Access/Secret keys which should be rotated quite often according to security best-practices. Relying on instance profile and assume-role allows us to completely forget about provisioning IAM users in different accounts.

I've also added compile version of the HPI file here: https://github.com/AlexejK/aws-credentials-plugin/releases/tag/aws-credentials-1.21-pr20 (for those who need to try this out but can't build themselves)