### PR TITLE
Add repositories and plugin repositories to POM.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,4 +85,17 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  
 </project>


### PR DESCRIPTION
Otherwise it does not build if you have no cached Parent POM XML

@reviewbybees