### PR TITLE
Updating to use latest verified version of credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.596.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.1</jenkins.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
+      <version>2.1.16</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
When a plugin was depending on older version of credentials plugin it causes findbugs-annotations.jar to be included in packaging.  This should bring things more closer to actual user  environments (upgraded to credentials 2.x)

@reviewbybees
