### PR TITLE
bumped to jdk7, bumped jenkins baseline to match jdk7 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.596.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.1</jenkins.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
In order to bump credentials to 2.x (https://github.com/jenkinsci/aws-credentials-plugin/pull/31)  we need to bump to jdk7 and update jenkins baseline accordingly.  Should be relatively safe since this is still an older version of jenkins

@reviewbybees

