### PR TITLE
Make the session token duration (or expiration) configurable by the user

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -62,30 +62,33 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
     private static final Logger LOGGER = Logger.getLogger(BaseAmazonWebServicesCredentials.class.getName());
 
     public static final int STS_CREDENTIALS_DURATION_SECONDS = 3600;
+
     private final String accessKey;
 
     private final Secret secretKey;
 
     private final String iamRoleArn;
     private final String iamMfaSerialNumber;
+    private final Integer stsTokenDuration;
 
     /**
      * Old data bound constructor. It is maintained to keep binary compatibility with clients that were using it directly.
      */
     public AWSCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id,
                               @CheckForNull String accessKey, @CheckForNull String secretKey, @CheckForNull String description) {
-        this(scope, id, accessKey, secretKey, description, null, null);
+        this(scope, id, accessKey, secretKey, description, null, null, null);
     }
 
     @DataBoundConstructor
     public AWSCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id,
                               @CheckForNull String accessKey, @CheckForNull String secretKey, @CheckForNull String description,
-                              @CheckForNull String iamRoleArn, @CheckForNull String iamMfaSerialNumber) {
+                              @CheckForNull String iamRoleArn, @CheckForNull String iamMfaSerialNumber, @CheckForNull Integer stsTokenDuration) {
         super(scope, id, description);
         this.accessKey = Util.fixNull(accessKey);
         this.secretKey = Secret.fromString(secretKey);
         this.iamRoleArn = Util.fixNull(iamRoleArn);
         this.iamMfaSerialNumber = Util.fixNull(iamMfaSerialNumber);
+        this.stsTokenDuration = stsTokenDuration == null ? STS_CREDENTIALS_DURATION_SECONDS : stsTokenDuration;
     }
 
     public String getAccessKey() {
@@ -102,6 +105,10 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
 
     public String getIamMfaSerialNumber() {
         return iamMfaSerialNumber;
+    }
+
+    public Integer getStsTokenDuration() {
+        return stsTokenDuration;
     }
 
     public boolean requiresToken() {
@@ -135,7 +142,8 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
 
         AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn)
                 .withSerialNumber(iamMfaSerialNumber)
-                .withTokenCode(mfaToken);
+                .withTokenCode(mfaToken)
+                .withDurationSeconds(stsTokenDuration);
 
         AssumeRoleResult assumeResult = new AWSSecurityTokenServiceClient(initialCredentials).assumeRole(assumeRequest);
 
@@ -159,7 +167,6 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
     private static AssumeRoleRequest createAssumeRoleRequest(@QueryParameter("iamRoleArn") String iamRoleArn) {
         return new AssumeRoleRequest()
                 .withRoleArn(iamRoleArn)
-                .withDurationSeconds(STS_CREDENTIALS_DURATION_SECONDS)
                 .withRoleSessionName(Jenkins.getActiveInstance().getDisplayName());
     }
 
@@ -171,10 +178,15 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
             return Messages.AWSCredentialsImpl_DisplayName();
         }
 
+        public Integer defaultStsTokenDuration() {
+            return STS_CREDENTIALS_DURATION_SECONDS;
+        }
+
         public FormValidation doCheckSecretKey(@QueryParameter("accessKey") final String accessKey,
                                                @QueryParameter("iamRoleArn") final String iamRoleArn,
                                                @QueryParameter("iamMfaSerialNumber") final String iamMfaSerialNumber,
                                                @QueryParameter("iamMfaToken") final String iamMfaToken,
+                                               @QueryParameter("stsTokenDuration") final Integer stsTokenDuration,
                                                @QueryParameter final String secretKey) {
             if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey)) {
                 return FormValidation.ok();
@@ -200,7 +212,8 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
             // If iamRoleArn is specified, swap out the credentials.
             if (!StringUtils.isBlank(iamRoleArn)) {
 
-                AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn);
+                AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn)
+                        .withDurationSeconds(stsTokenDuration);
 
                 if(!StringUtils.isBlank(iamMfaSerialNumber)) {
                     if(StringUtils.isBlank(iamMfaToken)) {
@@ -218,9 +231,10 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                             assumeResult.getCredentials().getAccessKeyId(),
                             assumeResult.getCredentials().getSecretAccessKey(),
                             assumeResult.getCredentials().getSessionToken());
+                    LOGGER.log(Level.INFO, "Assume role result: " + assumeResult.toString());
                 } catch(AmazonServiceException e) {
                     LOGGER.log(Level.WARNING, "Unable to assume role [" + iamRoleArn + "] with request [" + assumeRequest + "]", e);
-                    return FormValidation.error(Messages.AWSCredentialsImpl_NotAbleToAssumeRole());
+                    return FormValidation.error(Messages.AWSCredentialsImpl_NotAbleToAssumeRole() + " Check the Jenkins log for more details");
                 }
 
             }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
@@ -43,6 +43,9 @@
       <f:entry title="${%MFA Token}" field="iamMfaToken">
         <f:textbox/>
       </f:entry>
+      <f:entry title="${%STS Token Duration (sec)}" field="stsTokenDuration">
+        <f:textbox default="${descriptor.defaultStsTokenDuration()}"/>
+      </f:entry>
     </f:advanced>
   </f:section>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-stsTokenDuration.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-stsTokenDuration.html
@@ -1,0 +1,3 @@
+<div>
+    The duration, in seconds, for how long the obtained session token will be valid for.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/Messages.properties
@@ -26,7 +26,7 @@
 AWSCredentialsImpl_DisplayName=AWS Credentials
 AWSCredentialsImpl.SpecifyAccessKeyId=Please specify the Access Key ID
 AWSCredentialsImpl.SpecifySecretAccessKey=Please specify the Secret Access Key
-AWSCredentialsImpl.NotAbleToAssumeRole=There was an error assuming the specified IAM role, a MFA may be required by your organization
+AWSCredentialsImpl.NotAbleToAssumeRole=There was an error assuming the specified IAM role, a MFA may be required by your organization.
 AWSCredentialsImpl.SpecifyMFAToken=If the MFA Serial Number/ARN is specified, then a one time token is necessary to validate these credentials
 AWSCredentialsImpl.CredentialsValidWithAccessToNZones=These credentials are valid and have access to {0} availability zones
 AWSCredentialsImpl.CredentialsValidWithoutAccessToAwsServiceInZone=These credentials are valid but do not have access to the "{0}" service in the region "{1}". This message is not a problem if you need to access to other services or to other regions. Message: "{2}"


### PR DESCRIPTION
These changes will allow a user to configure the session token duration to something more than the default (1 hour).

The duration is in seconds. In most cases, the AWS role needs to be changed to allow a session token for longer than 1 hour, but this is a trivial thing to do through the AWS console. 