### PR TITLE
Correcting default credentials when using assumed roles

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+AWS+Credentials+Plugin</url>
 
   <scm>
-    <connection>scm:git:git@github.com:jenkinsci/cloudbees-aws-credentials-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/cloudbees-aws-credentials-plugin.git
-    </developerConnection>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.16</version>
+      <version>1.11.341</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,21 +29,22 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>3.25</version>
+    <relativePath />
   </parent>
 
   <artifactId>aws-credentials</artifactId>
-  <version>1.24-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
-  <name>CloudBees Amazon Web Services Credentials Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+AWS+Credentials+Plugin</url>
+  <name>CloudBees AWS Credentials Plugin</name>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+AWS+Credentials+Plugin</url>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <licenses>
@@ -54,7 +55,10 @@
   </licenses>
 
   <properties>
+    <revision>1.24</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>1.625.1</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <dependencies>
@@ -73,14 +77,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
       <version>1.7</version>
-    </dependency>
-    <!-- jenkins dependencies -->
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-accessKey.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-accessKey.html
@@ -1,0 +1,3 @@
+<div>
+    The access key and secret key may be left blank in case you are selecting an IAM role.
+</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<div>
+    Allows storing Amazon IAM credentials within the Jenkins Credentials API.
+    Store Amazon IAM access keys (AWSAccessKeyId and AWSSecretKey) within the Jenkins Credentials API.
+    Also support IAM Roles and IAM MFA Token.
+</div>


### PR DESCRIPTION
`InstanceProfileCredentialsProvider` only works under limited conditions. It is simpler and better to use the default provider chain from the AWS SDK.

May fix #29. Amends #20. Subsumes #41.

Who is the maintainer these days? CC @carlossg