### PR TITLE
JENKINS-57075 Remove workspace requirement

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -121,6 +121,10 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         @Override public String getDisplayName() {
             return "AWS access key and secret";
         }
+
+        @Override public boolean requiresWorkspace() {
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
Since the AWS credential type is managing two secret strings
(`accessKeyVariable` / `secretKeyVariable`), there is no need for a
workspace to access those secrets.