### PR TITLE
[FIXED JENKINS-57426] Make pipeline-model-extensions dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
       <version>1.3.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>variant</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
@@ -25,7 +25,7 @@
 package com.cloudbees.jenkins.plugins.awscredentials;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import hudson.Extension;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler;
 
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Extension
+@OptionalExtension(requirePlugins = "pipeline-model-extensions")
 public class AWSDeclarativeCredentialsHandler extends CredentialsBindingHandler<AmazonWebServicesCredentials> {
 
     @Nonnull


### PR DESCRIPTION
Can @abayer @amuniz please review it?

pipeline-model-extensions doesn't seem to be a required dependency. It is since https://github.com/jenkinsci/aws-credentials-plugin/pull/50 had been merged introducing undesired transitive dependencies.