### PR TITLE
[JENKINS-58842] - Trim Jenkins name for Role Session Names to avoid issues with trailing spaces in localizations

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -199,7 +199,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
     private static AssumeRoleRequest createAssumeRoleRequest(String iamRoleArn) {
         return new AssumeRoleRequest()
                 .withRoleArn(iamRoleArn)
-                .withRoleSessionName(Jenkins.getActiveInstance().getDisplayName().trim());
+                .withRoleSessionName("Jenkins");
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -199,7 +199,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
     private static AssumeRoleRequest createAssumeRoleRequest(String iamRoleArn) {
         return new AssumeRoleRequest()
                 .withRoleArn(iamRoleArn)
-                .withRoleSessionName(Jenkins.getActiveInstance().getDisplayName());
+                .withRoleSessionName(Jenkins.getActiveInstance().getDisplayName().trim());
     }
 
     @Extension


### PR DESCRIPTION
What could possibly go wrong when one uses a localized field for an AWS request session name? I have no idea why this field is used, maybe somebody overrides the "Jenkins" name in such way. I leave a full fix to the plugin maintainers who know the use-case, just fixing an obvious issue reported in https://issues.jenkins-ci.org/browse/JENKINS-58842

Fixes #67 

CC @diegombeltran 