### PR TITLE
[JENKINS-60057] AssumeRole does not honour proxy settings

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -227,7 +227,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
      * @return {@link ClientConfiguration}
      */
     private static ClientConfiguration getClientConfiguration() {
-        Jenkins instance = Jenkins.getInstance();
+        Jenkins instance = Jenkins.getInstanceOrNull();
 
         ProxyConfiguration proxy = instance != null ? instance.proxy : null;
         ClientConfiguration clientConfiguration = new ClientConfiguration();

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -144,7 +144,6 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                 clientRegion = Regions.DEFAULT_REGION.getName();
             }
 
-            ProxyConfiguration proxy = Jenkins.getInstanceOrNull().proxy;
             ClientConfiguration clientConfiguration = getClientConfiguration();
 
             AWSSecurityTokenService client;
@@ -228,9 +227,15 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
      * @return {@link ClientConfiguration}
      */
     private static ClientConfiguration getClientConfiguration() {
-        ProxyConfiguration proxy = Jenkins.getInstanceOrNull().proxy;
+        Jenkins instance = Jenkins.getInstanceOrNull();
+
+        if (instance == null) {
+            return null;
+        }
+
+        ProxyConfiguration proxy = instance.proxy;
         ClientConfiguration clientConfiguration = new ClientConfiguration();
-        if(proxy != null) {
+        if (proxy != null && proxy.name != null && proxy.name.isEmpty()) {
             clientConfiguration.setProxyHost(proxy.name);
             clientConfiguration.setProxyPort(proxy.port);
             clientConfiguration.setProxyUsername(proxy.getUserName());
@@ -290,8 +295,6 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                             assumeResult.getCredentials().getAccessKeyId(),
                             assumeResult.getCredentials().getSecretAccessKey(),
                             assumeResult.getCredentials().getSessionToken());
-
-
                 } catch(AmazonServiceException e) {
                     LOGGER.log(Level.WARNING, "Unable to assume role [" + iamRoleArn + "] with request [" + assumeRequest + "]", e);
                     return FormValidation.error(Messages.AWSCredentialsImpl_NotAbleToAssumeRole() + " Check the Jenkins log for more details");

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -227,13 +227,9 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
      * @return {@link ClientConfiguration}
      */
     private static ClientConfiguration getClientConfiguration() {
-        Jenkins instance = Jenkins.getInstanceOrNull();
+        Jenkins instance = Jenkins.getInstance();
 
-        if (instance == null) {
-            return null;
-        }
-
-        ProxyConfiguration proxy = instance.proxy;
+        ProxyConfiguration proxy = instance != null ? instance.proxy : null;
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         if (proxy != null && proxy.name != null && !proxy.name.isEmpty()) {
             clientConfiguration.setProxyHost(proxy.name);

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -215,14 +215,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
      * @return {@link AWSSecurityTokenService}
      */
     private static AWSSecurityTokenService getAWSSecurityTokenService(AWSCredentials awsCredentials) {
-        ProxyConfiguration proxy = Jenkins.getActiveInstance().proxy;
-        ClientConfiguration clientConfiguration = new ClientConfiguration();
-        if(proxy != null) {
-            clientConfiguration.setProxyHost(proxy.name);
-            clientConfiguration.setProxyPort(proxy.port);
-            clientConfiguration.setProxyUsername(proxy.getUserName());
-            clientConfiguration.setProxyPassword(proxy.getPassword());
-        }
+        ClientConfiguration clientConfiguration = getClientConfiguration();
         return AWSSecurityTokenServiceClientBuilder.standard()
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .withClientConfiguration(clientConfiguration)

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -235,7 +235,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
 
         ProxyConfiguration proxy = instance.proxy;
         ClientConfiguration clientConfiguration = new ClientConfiguration();
-        if (proxy != null && proxy.name != null && proxy.name.isEmpty()) {
+        if (proxy != null && proxy.name != null && !proxy.name.isEmpty()) {
             clientConfiguration.setProxyHost(proxy.name);
             clientConfiguration.setProxyPort(proxy.port);
             clientConfiguration.setProxyUsername(proxy.getUserName());


### PR DESCRIPTION
This is a follow-up of 

* https://github.com/jenkinsci/aws-credentials-plugin/issues/44
* https://issues.jenkins-ci.org/browse/JENKINS-60057

The idea is that AssumeRole gets the proxy configuration from Jenkins.