### PR TITLE
Support changing session token environment variable name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
@@ -43,6 +43,7 @@ public class AWSDeclarativeCredentialsHandler extends CredentialsBindingHandler<
     public List<MultiBinding<AmazonWebServicesCredentials>> toBindings(String varName, String credentialsId) {
         return Collections.singletonList(new AmazonWebServicesCredentialsBinding(varName + "_AWS_KEY_ID",
                 varName + "_AWS_SECRET",
+                varName + "_AWS_SESSION_TOKEN",
                 credentialsId));
     }
 
@@ -59,6 +60,7 @@ public class AWSDeclarativeCredentialsHandler extends CredentialsBindingHandler<
         map.put("$class", AmazonWebServicesCredentialsBinding.class.getName());
         map.put("keyIdVariable", new EnvVarResolver("%s_AWS_KEY_ID"));
         map.put("secretVariable", new EnvVarResolver("%s_AWS_SECRET"));
+        map.put("sessionTokenVariable", new EnvVarResolver("%s_AWS_SESSION_TOKEN"));
         map.put("credentialsId", credentialsId);
         return Collections.singletonList(map);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -55,24 +55,28 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     public final static String DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME = "AWS_ACCESS_KEY_ID";
     private final static String DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME = "AWS_SECRET_ACCESS_KEY";
-    private final static String SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
+    private final static String DEFAULT_SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
 
     @NonNull
     private final String accessKeyVariable;
     @NonNull
     private final String secretKeyVariable;
+    @NonNull
+    private final String sessionTokenVariable;
 
     /**
      *
      * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
      * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
+     * @param sessionTokenVariable if {@code null}, {@value DEFAULT_SESSION_TOKEN_VARIABLE_NAME} will be used.
      * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
      */
     @DataBoundConstructor
-    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId) {
+    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, @Nullable String sessionTokenVariable, String credentialsId) {
         super(credentialsId);
         this.accessKeyVariable = StringUtils.defaultIfBlank(accessKeyVariable, DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME);
         this.secretKeyVariable = StringUtils.defaultIfBlank(secretKeyVariable, DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME);
+        this.sessionTokenVariable = StringUtils.defaultIfBlank(sessionTokenVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME);
     }
 
     @NonNull
@@ -83,6 +87,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     public String getSecretKeyVariable() {
         return secretKeyVariable;
+    }
+
+    @NonNull
+    public String getSessionTokenVariable() {
+        return sessionTokenVariable;
     }
 
     @Override
@@ -99,14 +108,14 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
         // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
         if(credentials instanceof AWSSessionCredentials) {
-            m.put(SESSION_TOKEN_VARIABLE_NAME, ((AWSSessionCredentials) credentials).getSessionToken());
+            m.put(sessionTokenVariable, ((AWSSessionCredentials) credentials).getSessionToken());
         }
         return new MultiEnvironment(m);
     }
 
     @Override
     public Set<String> variables() {
-        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable));
+        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable, sessionTokenVariable));
     }
 
     @Symbol("aws")

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -79,6 +79,16 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         this.sessionTokenVariable = StringUtils.defaultIfBlank(sessionTokenVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME);
     }
 
+    /**
+     *
+     * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
+     * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
+     * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
+     */
+    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId) {
+        this(accessKeyVariable, secretKeyVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME, credentialsId);
+    }
+
     @NonNull
     public String getAccessKeyVariable() {
         return accessKeyVariable;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
@@ -30,4 +30,7 @@ THE SOFTWARE.
   <f:entry title="${%Secret Key Variable}" field="secretKeyVariable">
     <f:textbox default="AWS_SECRET_ACCESS_KEY"/>
   </f:entry>
+  <f:entry title="${%Session Token Variable}" field="sessionTokenVariable">
+    <f:textbox default="AWS_SESSION_TOKEN"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+<div>
+    Environment variable name for the AWS Session Token. If empty, <code>AWS_SESSION_TOKEN</code> will be used.</p>
+    This is used when you defined the role ARN when you setup the credential. If this key does not use Role, this can be ignored.
+</div>


### PR DESCRIPTION
This is a continuation of #39, rebased on current master and updated to include feedback from the original PR.

I didn't update the copyright statement, as mentioned in the original PR - I believe the file still does need some copyright statement, but I wasn't sure what to change it to, so I left it as-is.

I also wasn't sure if the `@DataBoundConstructor` annotation should go on the new constructor with the additional argument, or the old constructor, but I've put it on the new one here. Let me know if that needs to be changed!