### PR TITLE
Fix angry jenkins with broader exception handling

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -28,6 +28,7 @@ package com.cloudbees.jenkins.plugins.awscredentials;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -136,9 +137,8 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
             DefaultAwsRegionProviderChain sdkRegionLookup = new DefaultAwsRegionProviderChain();
             try {
                 clientRegion = sdkRegionLookup.getRegion();
-            }
-            catch(com.amazonaws.SdkClientException e) {
-                LOGGER.log(Level.WARNING,"Could not find default region using SDK lookup.", e);
+            } catch (com.amazonaws.SdkClientException e) {
+                LOGGER.log(Level.WARNING, "Could not find default region using SDK lookup.", e);
             }
             if (clientRegion == null) {
                 clientRegion = Regions.DEFAULT_REGION.getName();
@@ -148,7 +148,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
 
             AWSSecurityTokenService client;
             // Handle the case of delegation to instance profile
-            if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey.getPlainText()) ) {
+            if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey.getPlainText())) {
                 client = AWSSecurityTokenServiceClientBuilder.standard()
                         .withRegion(clientRegion)
                         .withClientConfiguration(clientConfiguration)
@@ -209,8 +209,8 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
 
     /**
      * Provides the {@link AWSSecurityTokenService} for a given {@link AWSCredentials}
-     * @param awsCredentials
      *
+     * @param awsCredentials
      * @return {@link AWSSecurityTokenService}
      */
     private static AWSSecurityTokenService getAWSSecurityTokenService(AWSCredentials awsCredentials) {
@@ -274,8 +274,8 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                 AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn)
                         .withDurationSeconds(stsTokenDuration);
 
-                if(!StringUtils.isBlank(iamMfaSerialNumber)) {
-                    if(StringUtils.isBlank(iamMfaToken)) {
+                if (!StringUtils.isBlank(iamMfaSerialNumber)) {
+                    if (StringUtils.isBlank(iamMfaToken)) {
                         return FormValidation.error(Messages.AWSCredentialsImpl_SpecifyMFAToken());
                     }
                     assumeRequest = assumeRequest
@@ -291,7 +291,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                             assumeResult.getCredentials().getAccessKeyId(),
                             assumeResult.getCredentials().getSecretAccessKey(),
                             assumeResult.getCredentials().getSessionToken());
-                } catch(AmazonServiceException e) {
+                } catch (SdkClientException e) {
                     LOGGER.log(Level.WARNING, "Unable to assume role [" + iamRoleArn + "] with request [" + assumeRequest + "]", e);
                     return FormValidation.error(Messages.AWSCredentialsImpl_NotAbleToAssumeRole() + " Check the Jenkins log for more details");
                 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -39,7 +39,6 @@ import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesResult;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -136,7 +136,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
             DefaultAwsRegionProviderChain sdkRegionLookup = new DefaultAwsRegionProviderChain();
             try {
                 clientRegion = sdkRegionLookup.getRegion();
-            } catch (com.amazonaws.SdkClientException e) {
+            } catch (RuntimeException e) {
                 LOGGER.log(Level.WARNING, "Could not find default region using SDK lookup.", e);
             }
             if (clientRegion == null) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -290,7 +290,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
                             assumeResult.getCredentials().getAccessKeyId(),
                             assumeResult.getCredentials().getSecretAccessKey(),
                             assumeResult.getCredentials().getSessionToken());
-                } catch (SdkClientException e) {
+                } catch (RuntimeException e) {
                     LOGGER.log(Level.WARNING, "Unable to assume role [" + iamRoleArn + "] with request [" + assumeRequest + "]", e);
                     return FormValidation.error(Messages.AWSCredentialsImpl_NotAbleToAssumeRole() + " Check the Jenkins log for more details");
                 }


### PR DESCRIPTION
* Auto-format `AWSCredentialsImpl.java`
* Change exception type from `AmazonServiceException` to `RuntimeException`

When garbage data is provided in the AWS credential configuration, the Amazon SDK throws a (previously uncaught) `SdkClientException` e.g. "unable to determine region ..." which caused an angry Jenkins to appear below the `secretKey` field. Now that the broad exception is caught, a much better looking error is shown which relays information about the `SdkClientException`.

Note: `AmazonServiceException` [is a subclass of](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/SdkClientException.html) `SdkClientException` and `RuntimeException`.