### PR TITLE
[JENKINS-65105]: Support for externalID when using role

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
@@ -37,6 +37,9 @@
       <f:entry title="${%IAM Role To Use}" field="iamRoleArn">
         <f:textbox/>
       </f:entry>
+      <f:entry title="${%External Id To Use}" field="iamExternalId">
+        <f:textbox/>
+      </f:entry>
       <f:entry title="${%MFA Serial Number}" field="iamMfaSerialNumber">
         <f:textbox/>
       </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/ConfigurationAsCodeTest.java
@@ -24,6 +24,7 @@ public class ConfigurationAsCodeTest extends RoundTripAbstractTest {
         assertEquals(credentials.getDescription(), "foo-description");
         assertEquals(credentials.getIamMfaSerialNumber(), "arn:aws:iam::123456789012:mfa/user");
         assertEquals(credentials.getIamRoleArn(), "arn:aws:iam::123456789012:role/MyIAMRoleName");
+        assertEquals(credentials.getIamExternalId(), "123456");
         assertEquals(credentials.getId(), "aws-credentials-casc");
         assertEquals(credentials.getScope(), CredentialsScope.GLOBAL);
         assertEquals(credentials.getSecretKey().getPlainText(), "bar");

--- a/src/test/resources/com/cloudbees/jenkins/plugins/awscredentials/configuration-as-code.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/awscredentials/configuration-as-code.yaml
@@ -7,6 +7,7 @@ credentials:
               description: "foo-description"
               iamMfaSerialNumber: "arn:aws:iam::123456789012:mfa/user"
               iamRoleArn: "arn:aws:iam::123456789012:role/MyIAMRoleName"
+              iamExternalId: "123456"
               id: "aws-credentials-casc"
               scope: GLOBAL
               secretKey: "bar"


### PR DESCRIPTION
Support for externalID when using role

When assuming role an external ID value may also need to be specified.
This change implements the use of external ID.
