### PR TITLE
Replace heavyweight aws-java-sdk with fine-grained aws-java-sdk-ec2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.27</version>
     <relativePath />
   </parent>
 
@@ -56,18 +56,25 @@
   <properties>
     <revision>1.31</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.164.3</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
+    <aws-java-sdk.version>1.12.70</aws-java-sdk.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.164.x</artifactId>
-        <version>10</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <version>950.v396cb834de1e</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <!-- fix upper bound -->
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.10.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -78,18 +85,13 @@
       <artifactId>credentials</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.341</version>
+      <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+      <artifactId>aws-java-sdk-ec2</artifactId>
+      <version>${aws-java-sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-      <version>2.10.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -119,7 +121,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Since 1.12.70, the `aws-java-sdk` plugin has been split into multiple fine-grained plugins.

This pull request replaces the heavyweight `aws-java-sdk` (195Mb) with a fine-grained `aws-java-sdk-ec2` dependency.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
