### PR TITLE
#116 Fixed aws validation issue cased by empty string in externalId

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -101,7 +101,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
         this.accessKey = Util.fixNull(accessKey);
         this.secretKey = Secret.fromString(secretKey);
         this.iamRoleArn = Util.fixNull(iamRoleArn);
-        this.iamExternalId = Util.fixNull(iamExternalId);
+        this.iamExternalId = Util.fixEmpty(iamExternalId);
         this.iamMfaSerialNumber = Util.fixNull(iamMfaSerialNumber);
     }
 


### PR DESCRIPTION
externalId is an optional parameter in AWS api. It has to either be null or more than 2 characters long. Using fixNull will simply give validation error if externalId is not defined in plugin configuration even though a null externalId is a valid usecase.
I have used fixEmpty instead of fixNull. This way if an empty string is presented as externalId to the plugin, we default it to null.
https://github.com/jenkinsci/aws-credentials-plugin/issues/116
<!-- Please describe your pull request here. -->

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
