### PR TITLE
[JENKINS-67452] Do not add blank external ids

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -229,7 +229,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
         AssumeRoleRequest retval = new AssumeRoleRequest()
                 .withRoleArn(iamRoleArn)
                 .withRoleSessionName("Jenkins");
-       if (iamExternalId.isEmpty()) {
+       if (iamExternalId != null && !iamExternalId.isEmpty()) {
            return retval.withExternalId(iamExternalId);
        }
        return retval;

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -226,10 +226,13 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials impleme
     }
 
     private static AssumeRoleRequest createAssumeRoleRequest(String iamRoleArn, String iamExternalId) {
-        return new AssumeRoleRequest()
+        AssumeRoleRequest retval = new AssumeRoleRequest()
                 .withRoleArn(iamRoleArn)
-                .withExternalId(iamExternalId)
                 .withRoleSessionName("Jenkins");
+       if (iamExternalId.isEmpty()) {
+           return retval.withExternalId(iamExternalId);
+       }
+       return retval;
     }
 
     /**


### PR DESCRIPTION
Fixes #116 

<!-- Please describe your pull request here. -->

check the `externalId` is not blank or empty before adding it.

this covers the existing case where a credential was created before the externalId field was introduced (null) as well as after it was where it would be converted to an empty String (which is not a valid external id)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
