### PR TITLE
Add an mfaToken option to the credentials binding

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -67,6 +67,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     private final String secretKeyVariable;
 
+    private String mfaToken;
     private String roleArn;
     private String roleSessionName;
     private int roleSessionDurationSeconds;
@@ -92,6 +93,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     public String getSecretKeyVariable() {
         return secretKeyVariable;
+    }
+
+    @DataBoundSetter
+    public void setMfaToken(String mfaToken) {
+        this.mfaToken = mfaToken;
     }
 
     @DataBoundSetter
@@ -121,7 +127,13 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
             provider = this.assumeRoleProvider(provider);
         }
 
-        AWSCredentials credentials = provider.getCredentials();
+        AWSCredentials credentials;
+        if (!StringUtils.isEmpty(this.mfaToken)) {
+            AmazonWebServicesCredentials awsProvider = (AmazonWebServicesCredentials) provider;
+            credentials = awsProvider.getCredentials(this.mfaToken);
+        } else {
+            credentials = provider.getCredentials();
+        }
 
         Map<String,String> m = new HashMap<String,String>();
         m.put(accessKeyVariable, credentials.getAWSAccessKeyId());


### PR DESCRIPTION
Closes #16.

This plugin has support for specifying AWS Credentials with an MFA device serial #, but doesn't actually expose a method of obtaining a session token from a pipeline if your credentials are configured as such.

This PR adds a new `mfaToken` option to the `AmazonWebServicesCredentialsBinding` class, which enables an approach like this in a pipeline. (This is a scripted pipeline example, but it should also work for declarative.)

```groovy
withCredentials([[
    $class: 'AmazonWebServicesCredentialsBinding',
    credentialsId: '${deployCredentialsId}', // odd templating due to JENKINS-58170
    mfaToken: mfaCode
]]) {
    // ...
}
```

In the above example, `deployCredentialsId` is a parameter to the pipeline (ideally pointing to AWS credentials attached to a specific user rather than system level credentials, which is why the parameter is interpolated as a template string. See [JENKINS-58170](https://issues.jenkins.io/browse/JENKINS-58170) for more info on this.)

The `mfaCode` variable is a parameter to the pipeline as well. This enables developers invoking a job to provide an MFA code from their authenticator device when starting the job, ensuring MFA still requires a human element.

This is a draft pull request. While I've built this plugin and verified it works with some basic manual testing, there are still a few unanswered questions that I'll need some assistance with:
- [ ] I was unable to run the test suite locally (I was developing in VS Code rather than a Java IDE, and it didn't work out of the box) so I'm unsure whether the existing tests (a) pass and (b) cover my additions. Help from a regular contributor here would be appreciated.
- [ ] I am unclear whether [this cast](https://github.com/weaversam8/aws-credentials-plugin/blob/786db33d214429c37ae0e42e2527c0ae7178e5a6/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java#L132) is appropriate. It "works", but I'm not sure how it covers edge cases elsewhere in the Jenkins Credentials ecosystem. Will `provider` ever be any type other than `AmazonWebServicesCredentials`? If so we may need a different solution. If not, why is this variable typed as `AWSCredentialsProvider` and not something else?

#### PR submission checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
