### PR TITLE
Increase spotbugs checks and fix redundant interface declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
     <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
     <aws-java-sdk.version>1.12.70</aws-java-sdk.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -62,7 +62,7 @@ import java.net.HttpURLConnection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials implements AmazonWebServicesCredentials {
+public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
 
     private static final long serialVersionUID = -3167989896315282034L;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Hello folks :wave:

I'm currently following the [Improve a Plugin documentation](https://www.jenkins.io/doc/developer/tutorial-improve/) for
Jenkins plugins modernization, and noticed we could [add more spotbugs checks](https://www.jenkins.io/doc/developer/tutorial-improve/add-more-spotbugs-checks/) for this plugin.

By doing so and running `mvn -DskipTests verify`, Spotbugs reported that `com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl` was implementing the interface `AmazonWebServicesCredentials`, but so is `BaseAmazonWebServicesCredentials`, which `AWSCredentialsImpl` extends, so I removed that redundant interface declaration.

I checked that everything was still fine with `mvn verify` and everything looks good.

Let me know if I missed anything with this PR.

Thanks a lot for your review!

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
