### PR TITLE
Added IamRoleRegion to Credential in order to set a custom sts region for sts Client

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -211,9 +211,9 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
         return accessKey + ":" + iamRoleArn;
     }
 
-    /*package*/ static AWSSecurityTokenService buildStsClient(AWSCredentialsProvider provider) {
+    /*package*/ static AWSSecurityTokenService buildStsClient(AWSCredentialsProvider provider, String awsRegion) {
         // Check for available region from the SDK, otherwise specify default
-        String clientRegion = determineClientRegion();
+        String clientRegion = StringUtils.defaultIfBlank(awsRegion, determineClientRegion());
 
         AWSSecurityTokenServiceClientBuilder builder = AWSSecurityTokenServiceClientBuilder.standard()
                         .withRegion(clientRegion)

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -50,6 +50,7 @@ import hudson.Extension;
 import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
@@ -69,6 +70,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
     private static final Logger LOGGER = Logger.getLogger(BaseAmazonWebServicesCredentials.class.getName());
 
     public static final int STS_CREDENTIALS_DURATION_SECONDS = 3600;
+    public static final String IAM_ROLE_REGION = "us-east-1";
 
     private final String accessKey;
 
@@ -77,6 +79,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
     private final String iamRoleArn;
     private final String iamExternalId;
     private final String iamMfaSerialNumber;
+    private final String iamRoleRegion;
 
     private volatile Integer stsTokenDuration;
 
@@ -93,17 +96,26 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
         this(scope, id, accessKey, secretKey, description, iamRoleArn, iamMfaSerialNumber, null);
     }
 
-    @DataBoundConstructor
+    // Old data bound constructor. It is maintained to keep binary compatibility with clients that were using it directly.
     public AWSCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id,
                               @CheckForNull String accessKey, @CheckForNull String secretKey, @CheckForNull String description,
                               @CheckForNull String iamRoleArn, @CheckForNull String iamMfaSerialNumber,
                               String iamExternalId) {
+        this(scope, id, accessKey, secretKey, description, iamRoleArn, iamMfaSerialNumber, iamExternalId, null);
+    }
+
+    @DataBoundConstructor
+    public AWSCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id,
+                              @CheckForNull String accessKey, @CheckForNull String secretKey, @CheckForNull String description,
+                              @CheckForNull String iamRoleArn, @CheckForNull String iamMfaSerialNumber,
+                              String iamExternalId, String iamRoleRegion) {
         super(scope, id, description);
         this.accessKey = Util.fixNull(accessKey);
         this.secretKey = Secret.fromString(secretKey);
         this.iamRoleArn = Util.fixNull(iamRoleArn);
         this.iamExternalId = Util.fixNull(iamExternalId);
         this.iamMfaSerialNumber = Util.fixNull(iamMfaSerialNumber);
+        this.iamRoleRegion = Util.fixNull(iamRoleRegion);
     }
 
     public String getAccessKey() {
@@ -124,6 +136,10 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
 
     public String getIamMfaSerialNumber() {
         return iamMfaSerialNumber;
+    }
+
+    public String getIamRoleRegion() {
+        return iamRoleRegion;
     }
 
     @NonNull
@@ -154,7 +170,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
                baseProvider = new AWSStaticCredentialsProvider(initialCredentials);
             }
 
-            AWSSecurityTokenService client = buildStsClient(baseProvider);
+            AWSSecurityTokenService client = buildStsClient(baseProvider, this.iamRoleRegion);
 
             AssumeRoleRequest assumeRequest = createAssumeRoleRequest(iamRoleArn, iamExternalId)
                     .withDurationSeconds(this.getStsTokenDuration());
@@ -211,9 +227,9 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
         return accessKey + ":" + iamRoleArn;
     }
 
-    /*package*/ static AWSSecurityTokenService buildStsClient(AWSCredentialsProvider provider, String awsRegion) {
+    /*package*/ static AWSSecurityTokenService buildStsClient(AWSCredentialsProvider provider, String iamRoleRegion) {
         // Check for available region from the SDK, otherwise specify default
-        String clientRegion = StringUtils.defaultIfBlank(awsRegion, determineClientRegion());
+        String clientRegion = StringUtils.defaultIfBlank(iamRoleRegion, determineClientRegion());
 
         AWSSecurityTokenServiceClientBuilder builder = AWSSecurityTokenServiceClientBuilder.standard()
                         .withRegion(clientRegion)
@@ -280,6 +296,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
         }
 
         public static final Integer DEFAULT_STS_TOKEN_DURATION = STS_CREDENTIALS_DURATION_SECONDS;
+        public static final String DEFAULT_IAM_ROLE_REGION = IAM_ROLE_REGION;
 
         @POST
         public FormValidation doCheckSecretKey(@QueryParameter("accessKey") final String accessKey,
@@ -288,6 +305,7 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
                                                @QueryParameter("iamMfaSerialNumber") final String iamMfaSerialNumber,
                                                @QueryParameter("iamMfaToken") final String iamMfaToken,
                                                @QueryParameter("stsTokenDuration") final Integer stsTokenDuration,
+                                               @QueryParameter("iamRoleRegion") final String iamRoleRegion,
                                                @QueryParameter final String secretKey) {
             if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 // for security reasons, do not perform any check if the user is not an admin

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -66,7 +66,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     private final String secretKeyVariable;
     @NonNull
-    private final String awsRegion;
+    private final String iamRoleRegion;
 
     private String roleArn;
     private String roleSessionName;
@@ -77,14 +77,14 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
      * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
      * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
      * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
-     * @param awsRegion region used to authenticate with sts.
+     * @param iamRoleRegion region used to authenticate with sts.
      */
     @DataBoundConstructor
-    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId,@Nullable String awsRegion) {
+    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId,@Nullable String iamRoleRegion) {
         super(credentialsId);
         this.accessKeyVariable = StringUtils.defaultIfBlank(accessKeyVariable, DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME);
         this.secretKeyVariable = StringUtils.defaultIfBlank(secretKeyVariable, DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME);
-        this.awsRegion = awsRegion;
+        this.iamRoleRegion = iamRoleRegion;
     }
 
     @NonNull
@@ -139,7 +139,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     }
 
     private AWSSessionCredentialsProvider assumeRoleProvider(AWSCredentialsProvider baseProvider) {
-        AWSSecurityTokenService stsClient = AWSCredentialsImpl.buildStsClient(baseProvider, this.awsRegion);
+        AWSSecurityTokenService stsClient = AWSCredentialsImpl.buildStsClient(baseProvider, this.iamRoleRegion);
 
         String roleSessionName = StringUtils.defaultIfBlank(this.roleSessionName, "Jenkins");
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -65,6 +65,8 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     private final String accessKeyVariable;
     @NonNull
     private final String secretKeyVariable;
+    @NonNull
+    private final String awsRegion;
 
     private String roleArn;
     private String roleSessionName;
@@ -75,12 +77,14 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
      * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
      * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
      * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
+     * @param awsRegion region used to authenticate with sts.
      */
     @DataBoundConstructor
-    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId) {
+    public AmazonWebServicesCredentialsBinding(@Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId,@Nullable String awsRegion) {
         super(credentialsId);
         this.accessKeyVariable = StringUtils.defaultIfBlank(accessKeyVariable, DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME);
         this.secretKeyVariable = StringUtils.defaultIfBlank(secretKeyVariable, DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME);
+        this.awsRegion = awsRegion;
     }
 
     @NonNull
@@ -135,7 +139,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     }
 
     private AWSSessionCredentialsProvider assumeRoleProvider(AWSCredentialsProvider baseProvider) {
-        AWSSecurityTokenService stsClient = AWSCredentialsImpl.buildStsClient(baseProvider);
+        AWSSecurityTokenService stsClient = AWSCredentialsImpl.buildStsClient(baseProvider, this.awsRegion);
 
         String roleSessionName = StringUtils.defaultIfBlank(this.roleSessionName, "Jenkins");
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/credentials.jelly
@@ -37,6 +37,9 @@
       <f:entry title="${%IAM Role To Use}" field="iamRoleArn">
         <f:textbox/>
       </f:entry>
+      <f:entry title="${%IAM Role Region}" field="iamRoleRegion">
+        <f:textbox/>
+      </f:entry>
       <f:entry title="${%External Id To Use}" field="iamExternalId">
         <f:textbox/>
       </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-iamRoleRegion.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl/help-iamRoleRegion.html
@@ -1,0 +1,3 @@
+<div>
+    The region used for the sts assume role.
+</div>


### PR DESCRIPTION
Added iamRoleRegion as attribute in:
- AmazonWebServicesCredentialsBinding.java 
   - updated constructor
   - updated assumeRoleProvider --> in buildStsClient now iamRoleRegion attribute is passed as argument
- AWSCredentialsImpl.java 
   - updated constructor and overloaded for compatibility
   - updated buildStsClient to include iamRoleRegion as parameter --> clientRegion now dynamically switches to determineClientRegion() if iamRoleRegion is null/empty
   - updated getCredentials() --> updated buildStsClient in order to match the updated method
- credentials.jelly
   - added entry under iamRoleArn for iamRoleRegion as textbox
- Added help-iamRoleRegion.html for help message 

### GUI Changes
**Before**
![image](https://github.com/jenkinsci/aws-credentials-plugin/assets/97523729/2caa84f9-dc29-497f-b893-0680432e3863)

**After**
![image](https://github.com/jenkinsci/aws-credentials-plugin/assets/97523729/8a494f8a-b3c0-48a6-9450-a4bdb400f211)

### Testing done
We created this simple use case:
```
pipeline {
    agent any
    parameters {
        string(name: 'region', defaultValue: "")
        string(name: 'credential', defaultValue: "")
    }
    stages {
        stage('TEST') {
            steps {
                withCredentials([[
                    $class: 'AmazonWebServicesCredentialsBinding',
                    credentialsId: "${params.credential}",
                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                ]]) {
                    sh "aws sts get-caller-identity --region ${params.region}"
                }
            }
        }

    }
}
```
**Problem found before iamRoleRegion**
Using the provided test over a credential:role we encountered this error **"The security token included in the request is invalid"** caused by the role being assumed in a different region then the target region for the aws cli operations. 
Thus to solve this problem iamRoleRegion has been added to the plugin Credential.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
