### PR TITLE
Add missing property accessors

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -93,6 +93,18 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         return secretKeyVariable;
     }
 
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
+
+    public int getRoleSessionDurationSeconds() {
+        return roleSessionDurationSeconds;
+    }
+
     @DataBoundSetter
     public void setRoleArn(String roleArn) {
         this.roleArn = roleArn;


### PR DESCRIPTION
When generating pipeline script for `withCredentials` with AWS credentials binding, the result script is not correct (fields are not set):
```
withCredentials([<object of type com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding>]) {
    // some block
}
```
Instead, it should generate something like:
```
withCredentials([[
    $class: 'AmazonWebServicesCredentialsBinding',
    credentialsId: '1de24f4f-2f81-433a-a900-b7fc4196f81f',
    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
]])
```
Steps to reproduce:
1. Start a Jenkins instance with AWS Credentials plugin installed
2. Create AWS Credentials (no need for real one)
3. Create pipeline and use the script syntax page to create `withCredentials` step using AWS credentials binding
4. Check the generated script snippet

The following exception is logged:
```
2024-03-20 16:29:53.774+0000 [id=56]    WARNING o.j.p.s.d.DescribableParameter#uncoerce: failed to uncoerce com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding@2db4c9ee
java.lang.UnsupportedOperationException: no public field ‘roleArn’ (or getter method) found in class com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.getValue(DescribableParameter.java:161)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.inspect(DescribableParameter.java:142)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2(DescribableModel.java:656)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2_(DescribableModel.java:754)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.uncoerce(DescribableParameter.java:196)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.uncoerce(DescribableParameter.java:190)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.inspect(DescribableParameter.java:142)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2(DescribableModel.java:656)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2_(DescribableModel.java:754)
        at org.jenkinsci.plugins.workflow.steps.StepDescriptor.uninstantiate(StepDescriptor.java:251)
        at org.jenkinsci.plugins.workflow.cps.Snippetizer.object2Groovy(Snippetizer.java:152)
        at org.jenkinsci.plugins.workflow.cps.Snippetizer.step2Groovy(Snippetizer.java:81)
        at org.jenkinsci.plugins.workflow.cps.Snippetizer.doGenerateSnippet(Snippetizer.java:522)
```

This adds the missing public access method to properties.