### PR TITLE
Fix "`NullPointerException`: Access key ID cannot be blank"

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -167,17 +167,17 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
 
     @Override
     public AwsCredentials resolveCredentials() {
-        AwsCredentials initialCredentials = AwsBasicCredentials.create(accessKey, secretKey.getPlainText());
 
         if (StringUtils.isBlank(iamRoleArn)) {
-            return initialCredentials;
+            return AwsBasicCredentials.create(accessKey, secretKey.getPlainText());
         } else {
             AwsCredentialsProvider baseProvider;
             // Handle the case of delegation to instance profile
             if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey.getPlainText())) {
                 baseProvider = null;
             } else {
-                baseProvider = StaticCredentialsProvider.create(initialCredentials);
+                baseProvider = StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey.getPlainText()));
             }
 
             StsClient client = buildStsClient(baseProvider);


### PR DESCRIPTION
Fixes #258

### Testing done

Created an AWS credential with global scope, left Access Key ID and Secret Access Key blank, filled in IAM role only. Tested the connection in the Artifact Manager on S3 configuration page and got the error mentioned in the issue report. Tested again with this PR and could no longer reproduce.