### PR TITLE
Only use `accessKey` and `secretKey` if they are not blank

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -169,7 +169,12 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
     public AwsCredentials resolveCredentials() {
 
         if (StringUtils.isBlank(iamRoleArn)) {
-            return AwsBasicCredentials.create(accessKey, secretKey.getPlainText());
+            if (StringUtils.isBlank(accessKey) && StringUtils.isBlank(secretKey.getPlainText())) {
+                // AWS SDK v2 does not allow blank accessKey and secretKey
+                return null;
+            } else {
+                return AwsBasicCredentials.create(accessKey, secretKey.getPlainText());
+            }
         } else {
             AwsCredentialsProvider baseProvider;
             // Handle the case of delegation to instance profile

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
@@ -139,8 +140,14 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         AwsCredentials credentials = provider.resolveCredentials();
 
         Map<String, String> m = new HashMap<String, String>();
-        m.put(accessKeyVariable, credentials.accessKeyId());
-        m.put(secretKeyVariable, credentials.secretAccessKey());
+        if (Objects.isNull(credentials)) {
+            // the empty strings retain functionality present before the AWS SDK migration
+            m.put(accessKeyVariable, "");
+            m.put(secretKeyVariable, "");
+        } else {
+            m.put(accessKeyVariable, credentials.accessKeyId());
+            m.put(secretKeyVariable, credentials.secretAccessKey());
+        }
 
         // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
         if (credentials instanceof AwsSessionCredentials) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
@@ -140,11 +139,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         AwsCredentials credentials = provider.resolveCredentials();
 
         Map<String, String> m = new HashMap<String, String>();
-        if (Objects.isNull(credentials)) {
-            // the empty strings retain functionality present before the AWS SDK migration
-            m.put(accessKeyVariable, "");
-            m.put(secretKeyVariable, "");
-        } else {
+        if (credentials != null) {
             m.put(accessKeyVariable, credentials.accessKeyId());
             m.put(secretKeyVariable, credentials.secretAccessKey());
         }


### PR DESCRIPTION
Only use the accessKey and secretKey if they are provided. Before it was only checking if role was blank. This allows the creation of a secret that uses the instance profile. This is useful if you want to parameterize the secret being passed in - one for the instance profile and a different one for a different account. This functionality existed before in earlier versions of the plugin, this is restoring that functionality.

Fixes https://github.com/jenkinsci/aws-credentials-plugin/issues/264

### Testing done

* Installed latest version `240.v6d844a_6f5480`
* Created two credentials:
  * one named `withKey` that had a valid access and secret access key (from a second account) and blank role
  * one named `withBlanks` that had a blank access key, blank secret access key, and blank role
* Ran a job that called `aws s3 ls` wrapped in withCredentials with both credentials
* The one using `withKey` worked and listed buckets in the second account
* The one using `withBlanks` failed with NullPointerException
* Installed the plugin version from the PR and reran the job
* This time both blocks printed out buckets, one from the second account and one from the account the Jenkins node was running within

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


