### PR TITLE
feat: make session token env variable configurable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandler.java
@@ -49,6 +49,7 @@ public class AWSDeclarativeCredentialsHandler extends CredentialsBindingHandler<
         map.put("$class", AmazonWebServicesCredentialsBinding.class.getName());
         map.put("keyIdVariable", new EnvVarResolver("%s_AWS_KEY_ID"));
         map.put("secretVariable", new EnvVarResolver("%s_AWS_SECRET"));
+        map.put("sessionTokenVariable", new EnvVarResolver("%s_AWS_SESSION_TOKEN"));
         map.put("credentialsId", credentialsId);
         return Collections.singletonList(map);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -58,13 +58,16 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     public static final String DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME = "AWS_ACCESS_KEY_ID";
     private static final String DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME = "AWS_SECRET_ACCESS_KEY";
-    private static final String SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
+    private static final String DEFAULT_SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
 
     @NonNull
     private final String accessKeyVariable;
 
     @NonNull
     private final String secretKeyVariable;
+
+    @NonNull
+    private final String sessionTokenVariable;
 
     private String roleArn;
     private String roleSessionName;
@@ -74,14 +77,20 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
      *
      * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
      * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
+     * @param sessionTokenVariable if {@code null}, {@value DEFAULT_SESSION_TOKEN_VARIABLE_NAME} will be used.
      * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
      */
     @DataBoundConstructor
     public AmazonWebServicesCredentialsBinding(
-            @Nullable String accessKeyVariable, @Nullable String secretKeyVariable, String credentialsId) {
+            @Nullable String accessKeyVariable,
+            @Nullable String secretKeyVariable,
+            @Nullable String sessionTokenVariable,
+            String credentialsId) {
         super(credentialsId);
         this.accessKeyVariable = StringUtils.defaultIfBlank(accessKeyVariable, DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME);
         this.secretKeyVariable = StringUtils.defaultIfBlank(secretKeyVariable, DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME);
+        this.sessionTokenVariable =
+                StringUtils.defaultIfBlank(sessionTokenVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME);
     }
 
     @NonNull
@@ -92,6 +101,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     public String getSecretKeyVariable() {
         return secretKeyVariable;
+    }
+
+    @NonNull
+    public String getSessionTokenVariable() {
+        return sessionTokenVariable;
     }
 
     @Nullable
@@ -142,11 +156,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
         if (credentials != null) {
             m.put(accessKeyVariable, credentials.accessKeyId());
             m.put(secretKeyVariable, credentials.secretAccessKey());
-        }
 
-        // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
-        if (credentials instanceof AwsSessionCredentials) {
-            m.put(SESSION_TOKEN_VARIABLE_NAME, ((AwsSessionCredentials) credentials).sessionToken());
+            // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
+            if (credentials instanceof AwsSessionCredentials) {
+                m.put(sessionTokenVariable, ((AwsSessionCredentials) credentials).sessionToken());
+            }
         }
         return new MultiEnvironment(m);
     }
@@ -171,7 +185,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     @Override
     public Set<String> variables() {
-        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable, SESSION_TOKEN_VARIABLE_NAME));
+        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable, sessionTokenVariable));
     }
 
     @Symbol("aws")

--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -67,7 +67,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     private final String secretKeyVariable;
 
     @NonNull
-    private final String sessionTokenVariable;
+    private String sessionTokenVariable = DEFAULT_SESSION_TOKEN_VARIABLE_NAME;
 
     private String roleArn;
     private String roleSessionName;
@@ -77,20 +77,16 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
      *
      * @param accessKeyVariable if {@code null}, {@value DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME} will be used.
      * @param secretKeyVariable if {@code null}, {@value DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME} will be used.
-     * @param sessionTokenVariable if {@code null}, {@value DEFAULT_SESSION_TOKEN_VARIABLE_NAME} will be used.
      * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
      */
     @DataBoundConstructor
     public AmazonWebServicesCredentialsBinding(
             @Nullable String accessKeyVariable,
             @Nullable String secretKeyVariable,
-            @Nullable String sessionTokenVariable,
             String credentialsId) {
         super(credentialsId);
         this.accessKeyVariable = StringUtils.defaultIfBlank(accessKeyVariable, DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME);
         this.secretKeyVariable = StringUtils.defaultIfBlank(secretKeyVariable, DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME);
-        this.sessionTokenVariable =
-                StringUtils.defaultIfBlank(sessionTokenVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME);
     }
 
     @NonNull
@@ -106,6 +102,11 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     public String getSessionTokenVariable() {
         return sessionTokenVariable;
+    }
+
+    @DataBoundSetter
+    public void setSessionTokenVariable(@Nullable String sessionTokenVariable) {
+        this.sessionTokenVariable = StringUtils.defaultIfBlank(sessionTokenVariable, DEFAULT_SESSION_TOKEN_VARIABLE_NAME);
     }
 
     @Nullable

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
@@ -30,4 +30,7 @@ THE SOFTWARE.
   <f:entry title="${%Secret Key Variable}" field="secretKeyVariable">
     <f:textbox default="AWS_SECRET_ACCESS_KEY"/>
   </f:entry>
+  <f:entry title="${%Session Token Variable}" field="sessionTokenVariable">
+    <f:textbox default="AWS_SESSION_TOKEN"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+<div>
+    Environment variable name for the AWS Session Token when using IAM Role. If empty, <code>AWS_SESSION_TOKEN</code> will be used.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help.html
@@ -1,3 +1,3 @@
 <div>
-    Sets one variable to the AWS access key and another one to the secret key given in the credentials.
+    Sets one variable to the AWS access key, another one to the secret key, and if IAM Role is used, a third variable to the session token.
 </div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingIntegrationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.cloudbees.jenkins.plugins.awscredentials;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration tests for AWS Credentials Plugin that test the binding of credentials in a Jenkins job.
+ */
+public class AWSCredentialsBindingIntegrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private static final String CREDENTIAL_ID = "aws-integration-test-cred";
+    private static final String ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    /**
+     * Test binding of AWS credentials in a Freestyle project shell step.
+     */
+    @Test
+    public void testFreeStyleProjectCredentialBinding() throws Exception {
+        // Create and store the credential
+        AWSCredentialsImpl credentials = new AWSCredentialsImpl(
+                CredentialsScope.GLOBAL, CREDENTIAL_ID, ACCESS_KEY, SECRET_KEY, "Integration Test Credential");
+
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
+
+        // Create a freestyle project with AWS credential binding
+        FreeStyleProject project = j.createFreeStyleProject("aws-cred-freestyle-test");
+
+        // Configure credential binding
+        List<MultiBinding<? extends Credentials>> binders = new ArrayList<>();
+        binders.add(new AmazonWebServicesCredentialsBinding(
+                "AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN", CREDENTIAL_ID));
+
+        SecretBuildWrapper wrapper = new SecretBuildWrapper(binders);
+        project.getBuildWrappersList().add(wrapper);
+
+        // Add a shell/batch step that echoes the bound variables with base64 encoding
+        String command;
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            command = "echo AWS Access Key: %AWS_ACCESS_KEY%\r\n"
+                    + "echo AWS Secret Key B64: | powershell -command \"[convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($env:AWS_SECRET_KEY))\"";
+            project.getBuildersList().add(new BatchFile(command));
+        } else {
+            command = "echo AWS Access Key: $AWS_ACCESS_KEY\n"
+                    + "echo AWS Secret Key B64: $(echo -n $AWS_SECRET_KEY | base64)";
+            project.getBuildersList().add(new Shell(command));
+        }
+
+        // Run the build
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Verify results
+        j.assertBuildStatus(Result.SUCCESS, build);
+        // Credentials are masked in the logs with ****
+        j.assertLogContains("AWS Access Key: ****", build);
+        j.assertLogContains("AWS Secret Key B64:", build);
+        // Verify the raw secret key is not exposed
+        j.assertLogNotContains(SECRET_KEY, build);
+        // We don't want to expose the secret key in the log, just verify it was set
+        j.assertLogNotContains(SECRET_KEY, build);
+    }
+
+    /**
+     * Test binding of AWS credentials in a Pipeline job.
+     */
+    @Test
+    public void testPipelineCredentialBinding() throws Exception {
+        // Create and store the credential
+        AWSCredentialsImpl credentials = new AWSCredentialsImpl(
+                CredentialsScope.GLOBAL, CREDENTIAL_ID, ACCESS_KEY, SECRET_KEY, "Integration Test Credential");
+
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
+
+        // Create a pipeline job with AWS credential binding
+        WorkflowJob pipeline = j.createProject(WorkflowJob.class, "aws-cred-pipeline-test");
+
+        // Use a minimal pipeline format with only the binding - no shell commands
+        // This is because 'sh' and 'node' steps are not available in test environments
+        String pipelineScript = "withCredentials([\n" + "    [\n"
+                + "        $class: 'AmazonWebServicesCredentialsBinding',\n"
+                + "        credentialsId: '"
+                + CREDENTIAL_ID + "',\n" + "        accessKeyVariable: 'AWS_ACCESS_KEY',\n"
+                + "        secretKeyVariable: 'AWS_SECRET_KEY',\n"
+                + "        sessionTokenVariable: 'AWS_SESSION_TOKEN'\n"
+                + "    ]\n"
+                + "]) {\n"
+                + "    // We can't use 'sh' or 'echo' in test environment\n"
+                + "    // Just testing that binding works without error\n"
+                + "}";
+
+        pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+
+        // Run the pipeline
+        WorkflowRun run = pipeline.scheduleBuild2(0).get();
+
+        // Verify results
+        j.assertBuildStatus(Result.SUCCESS, run);
+
+        // Check for binding evidence in logs
+        j.assertLogContains("Masking supported pattern matches of $AWS_SECRET_KEY or $AWS_ACCESS_KEY", run);
+        j.assertLogNotContains(SECRET_KEY, run);
+    }
+
+    /**
+     * Test binding of AWS credentials with role assumption in a Pipeline job.
+     */
+    @Test
+    public void testPipelineWithRoleAssumption() throws Exception {
+        // Create and store the credential with role information
+        String ROLE_ARN = "arn:aws:iam::123456789012:role/test-role";
+        AWSCredentialsImpl credentials = new AWSCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                CREDENTIAL_ID,
+                ACCESS_KEY,
+                SECRET_KEY,
+                "Integration Test Credential with Role",
+                ROLE_ARN,
+                null,
+                null);
+
+        // Set token duration
+        credentials.setStsTokenDuration(900);
+
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
+
+        // Create a pipeline job with AWS credential binding
+        WorkflowJob pipeline = j.createProject(WorkflowJob.class, "aws-role-pipeline-test");
+
+        // Use a simpler script format with explicit binding class
+        // Avoiding 'node' step which is not available in some test environments
+        String pipelineScript = "withCredentials([\n" + "    [\n"
+                + "        $class: 'AmazonWebServicesCredentialsBinding',\n"
+                + "        credentialsId: '"
+                + CREDENTIAL_ID + "',\n" + "        accessKeyVariable: 'AWS_ACCESS_KEY',\n"
+                + "        secretKeyVariable: 'AWS_SECRET_KEY',\n"
+                + "        sessionTokenVariable: 'AWS_SESSION_TOKEN'\n"
+                + "    ]\n"
+                + "]) {\n"
+                + "    // We can't use 'sh' or 'echo' in test environment\n"
+                + "    // Just testing that binding mechanism works without error\n"
+                + "}";
+
+        pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+
+        // In an actual test environment, we'd mock the STS client to simulate role assumption
+        // For this test, we're just verifying that the credentials binding mechanism is working
+        // Note: Since we can't actually call AWS STS in the test, the build might fail, which is expected
+        WorkflowRun run = pipeline.scheduleBuild2(0).get();
+
+        // We expect an STS exception since we're using fake credentials
+        // Just verify the credentials binding mechanism is initiated
+        j.assertLogContains("withCredentials", run);
+
+        // The STS exception should be logged if role assumption is attempted
+        // This indirectly verifies that the credentials binding is working properly
+        j.assertLogContains("software.amazon.awssdk.services.sts", run);
+    }
+
+    /**
+     * Test custom environment variable names for AWS credential binding.
+     */
+    @Test
+    public void testCustomVariableNames() throws Exception {
+        // Create and store the credential
+        AWSCredentialsImpl credentials = new AWSCredentialsImpl(
+                CredentialsScope.GLOBAL, CREDENTIAL_ID, ACCESS_KEY, SECRET_KEY, "Integration Test Credential");
+
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
+
+        // Create a freestyle project with AWS credential binding using custom variable names
+        FreeStyleProject project = j.createFreeStyleProject("aws-custom-vars-test");
+
+        // Configure credential binding with custom variable names
+        List<MultiBinding<? extends Credentials>> binders = new ArrayList<>();
+        binders.add(new AmazonWebServicesCredentialsBinding(
+                "CUSTOM_AWS_ACCESS_KEY", "CUSTOM_AWS_SECRET_KEY", "CUSTOM_AWS_TOKEN", CREDENTIAL_ID));
+
+        SecretBuildWrapper wrapper = new SecretBuildWrapper(binders);
+        project.getBuildWrappersList().add(wrapper);
+        // Add a shell/batch step that echoes the bound variables with base64 encoding
+        String command;
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            command = "echo Custom Access Key: %CUSTOM_AWS_ACCESS_KEY%\r\n"
+                    + "echo Custom Secret Key B64: | powershell -command \"[convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($env:CUSTOM_AWS_SECRET_KEY))\"";
+            project.getBuildersList().add(new BatchFile(command));
+        } else {
+            command = "echo Custom Access Key: $CUSTOM_AWS_ACCESS_KEY\n"
+                    + "echo Custom Secret Key B64: $(echo -n $CUSTOM_AWS_SECRET_KEY | base64)";
+            project.getBuildersList().add(new Shell(command));
+        }
+
+        // Run the build
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Verify results
+        j.assertBuildStatus(Result.SUCCESS, build);
+        j.assertLogContains("Custom Access Key: ****", build);
+        j.assertLogContains("Custom Secret Key B64:", build);
+        j.assertLogNotContains(SECRET_KEY, build);
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingIntegrationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingIntegrationTest.java
@@ -49,7 +49,7 @@ public class AWSCredentialsBindingIntegrationTest {
         // Configure credential binding
         List<MultiBinding<? extends Credentials>> binders = new ArrayList<>();
         binders.add(new AmazonWebServicesCredentialsBinding(
-                "AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN", CREDENTIAL_ID));
+                "AWS_ACCESS_KEY", "AWS_SECRET_KEY", CREDENTIAL_ID));
 
         SecretBuildWrapper wrapper = new SecretBuildWrapper(binders);
         project.getBuildWrappersList().add(wrapper);
@@ -100,8 +100,7 @@ public class AWSCredentialsBindingIntegrationTest {
                 + "        $class: 'AmazonWebServicesCredentialsBinding',\n"
                 + "        credentialsId: '"
                 + CREDENTIAL_ID + "',\n" + "        accessKeyVariable: 'AWS_ACCESS_KEY',\n"
-                + "        secretKeyVariable: 'AWS_SECRET_KEY',\n"
-                + "        sessionTokenVariable: 'AWS_SESSION_TOKEN'\n"
+                + "        secretKeyVariable: 'AWS_SECRET_KEY'\n"
                 + "    ]\n"
                 + "]) {\n"
                 + "    // We can't use 'sh' or 'echo' in test environment\n"
@@ -192,8 +191,10 @@ public class AWSCredentialsBindingIntegrationTest {
 
         // Configure credential binding with custom variable names
         List<MultiBinding<? extends Credentials>> binders = new ArrayList<>();
-        binders.add(new AmazonWebServicesCredentialsBinding(
-                "CUSTOM_AWS_ACCESS_KEY", "CUSTOM_AWS_SECRET_KEY", "CUSTOM_AWS_TOKEN", CREDENTIAL_ID));
+        AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
+                "CUSTOM_AWS_ACCESS_KEY", "CUSTOM_AWS_SECRET_KEY", CREDENTIAL_ID);
+        binding.setSessionTokenVariable("CUSTOM_AWS_TOKEN");
+        binders.add(binding);
 
         SecretBuildWrapper wrapper = new SecretBuildWrapper(binders);
         project.getBuildWrappersList().add(wrapper);

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingTest.java
@@ -1,0 +1,100 @@
+package com.cloudbees.jenkins.plugins.awscredentials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Simple unit tests for AmazonWebServicesCredentialsBinding that don't require the Jenkins infrastructure.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AWSCredentialsBindingTest {
+
+    @Test
+    public void testCustomSessionTokenVariable() {
+        AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
+                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "CUSTOM_SESSION_TOKEN", "credentials-id");
+
+        assertEquals("CUSTOM_ACCESS_KEY", binding.getAccessKeyVariable());
+        assertEquals("CUSTOM_SECRET_KEY", binding.getSecretKeyVariable());
+        assertEquals("CUSTOM_SESSION_TOKEN", binding.getSessionTokenVariable());
+
+        Set<String> variables = binding.variables();
+        assertTrue("Should contain access key variable", variables.contains("CUSTOM_ACCESS_KEY"));
+        assertTrue("Should contain secret key variable", variables.contains("CUSTOM_SECRET_KEY"));
+        assertTrue("Should contain session token variable", variables.contains("CUSTOM_SESSION_TOKEN"));
+    }
+
+    @Test
+    public void testDefaultValues() {
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+
+        assertEquals("AWS_ACCESS_KEY_ID", binding.getAccessKeyVariable());
+        assertEquals("AWS_SECRET_ACCESS_KEY", binding.getSecretKeyVariable());
+        assertEquals("AWS_SESSION_TOKEN", binding.getSessionTokenVariable());
+    }
+
+    @Test
+    public void testRoleProperties() {
+        AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
+                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "CUSTOM_SESSION_TOKEN", "credentials-id");
+
+        assertNull(binding.getRoleArn());
+        assertNull(binding.getRoleSessionName());
+        assertEquals(0, binding.getRoleSessionDurationSeconds());
+
+        String roleArn = "arn:aws:iam::123456789012:role/test-role";
+        String sessionName = "test-session";
+        int duration = 3600;
+
+        binding.setRoleArn(roleArn);
+        binding.setRoleSessionName(sessionName);
+        binding.setRoleSessionDurationSeconds(duration);
+
+        assertEquals(roleArn, binding.getRoleArn());
+        assertEquals(sessionName, binding.getRoleSessionName());
+        assertEquals(duration, binding.getRoleSessionDurationSeconds());
+    }
+
+    @Test
+    public void testType() {
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+
+        assertEquals(AmazonWebServicesCredentials.class, binding.type());
+    }
+
+    @Test
+    public void testVariables() {
+        AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
+                "AWS_ACCESS_KEY_ID_VAR", "AWS_SECRET_KEY_VAR", "AWS_SESSION_TOKEN_VAR", "credentials-id");
+
+        Set<String> variables = binding.variables();
+        assertEquals(3, variables.size());
+        assertTrue(variables.contains("AWS_ACCESS_KEY_ID_VAR"));
+        assertTrue(variables.contains("AWS_SECRET_KEY_VAR"));
+        assertTrue(variables.contains("AWS_SESSION_TOKEN_VAR"));
+    }
+
+    @Test
+    public void testAssumeRoleProvider() {
+        // This method is private and would need integration tests or refactoring to be properly tested
+        // For now, we'll just check if the assumeRole setter methods work correctly
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+
+        binding.setRoleArn("arn:aws:iam::123456789012:role/role-name");
+        binding.setRoleSessionName("customSession");
+        binding.setRoleSessionDurationSeconds(900);
+
+        assertEquals("arn:aws:iam::123456789012:role/role-name", binding.getRoleArn());
+        assertEquals("customSession", binding.getRoleSessionName());
+        assertEquals(900, binding.getRoleSessionDurationSeconds());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsBindingTest.java
@@ -18,7 +18,8 @@ public class AWSCredentialsBindingTest {
     @Test
     public void testCustomSessionTokenVariable() {
         AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
-                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "CUSTOM_SESSION_TOKEN", "credentials-id");
+                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "credentials-id");
+        binding.setSessionTokenVariable("CUSTOM_SESSION_TOKEN");
 
         assertEquals("CUSTOM_ACCESS_KEY", binding.getAccessKeyVariable());
         assertEquals("CUSTOM_SECRET_KEY", binding.getSecretKeyVariable());
@@ -33,7 +34,7 @@ public class AWSCredentialsBindingTest {
     @Test
     public void testDefaultValues() {
         AmazonWebServicesCredentialsBinding binding =
-                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+                new AmazonWebServicesCredentialsBinding(null, null, "credentials-id");
 
         assertEquals("AWS_ACCESS_KEY_ID", binding.getAccessKeyVariable());
         assertEquals("AWS_SECRET_ACCESS_KEY", binding.getSecretKeyVariable());
@@ -43,7 +44,8 @@ public class AWSCredentialsBindingTest {
     @Test
     public void testRoleProperties() {
         AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
-                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "CUSTOM_SESSION_TOKEN", "credentials-id");
+                "CUSTOM_ACCESS_KEY", "CUSTOM_SECRET_KEY", "credentials-id");
+        binding.setSessionTokenVariable("CUSTOM_SESSION_TOKEN");
 
         assertNull(binding.getRoleArn());
         assertNull(binding.getRoleSessionName());
@@ -65,7 +67,7 @@ public class AWSCredentialsBindingTest {
     @Test
     public void testType() {
         AmazonWebServicesCredentialsBinding binding =
-                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+                new AmazonWebServicesCredentialsBinding(null, null, "credentials-id");
 
         assertEquals(AmazonWebServicesCredentials.class, binding.type());
     }
@@ -73,7 +75,8 @@ public class AWSCredentialsBindingTest {
     @Test
     public void testVariables() {
         AmazonWebServicesCredentialsBinding binding = new AmazonWebServicesCredentialsBinding(
-                "AWS_ACCESS_KEY_ID_VAR", "AWS_SECRET_KEY_VAR", "AWS_SESSION_TOKEN_VAR", "credentials-id");
+                "AWS_ACCESS_KEY_ID_VAR", "AWS_SECRET_KEY_VAR", "credentials-id");
+        binding.setSessionTokenVariable("AWS_SESSION_TOKEN_VAR");
 
         Set<String> variables = binding.variables();
         assertEquals(3, variables.size());
@@ -87,7 +90,7 @@ public class AWSCredentialsBindingTest {
         // This method is private and would need integration tests or refactoring to be properly tested
         // For now, we'll just check if the assumeRole setter methods work correctly
         AmazonWebServicesCredentialsBinding binding =
-                new AmazonWebServicesCredentialsBinding(null, null, null, "credentials-id");
+                new AmazonWebServicesCredentialsBinding(null, null, "credentials-id");
 
         binding.setRoleArn("arn:aws:iam::123456789012:role/role-name");
         binding.setRoleSessionName("customSession");

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandlerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AWSDeclarativeCredentialsHandlerTest.java
@@ -1,0 +1,68 @@
+package com.cloudbees.jenkins.plugins.awscredentials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for the {@link AWSDeclarativeCredentialsHandler} class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AWSDeclarativeCredentialsHandlerTest {
+
+    private AWSDeclarativeCredentialsHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new AWSDeclarativeCredentialsHandler();
+    }
+
+    @Test
+    public void testType() {
+        // Verify that the handler returns the correct credential type
+        assertEquals(AmazonWebServicesCredentials.class, handler.type());
+    }
+
+    @Test
+    public void testGetWithCredentialsParameters() {
+        // Test credential ID
+        String credentialsId = "test-credentials-id";
+
+        // Get parameters
+        List<Map<String, Object>> parameters = handler.getWithCredentialsParameters(credentialsId);
+
+        // Verify the result is not null and has exactly one entry
+        assertNotNull("Parameters should not be null", parameters);
+        assertEquals("Should return a singleton list", 1, parameters.size());
+
+        // Get the map from the list
+        Map<String, Object> paramMap = parameters.get(0);
+
+        // Verify the class name
+        assertEquals(
+                "Class name should match AmazonWebServicesCredentialsBinding",
+                AmazonWebServicesCredentialsBinding.class.getName(),
+                paramMap.get("$class"));
+
+        // Verify credentials ID
+        assertEquals("Credentials ID should match the provided value", credentialsId, paramMap.get("credentialsId"));
+
+        // Verify key format variables
+        assertTrue("Should contain keyIdVariable", paramMap.containsKey("keyIdVariable"));
+        assertTrue("Should contain secretVariable", paramMap.containsKey("secretVariable"));
+        assertTrue("Should contain sessionTokenVariable", paramMap.containsKey("sessionTokenVariable"));
+
+        // Verify the EnvVarResolver objects (we can only test that they're not null, as we don't have access to the
+        // EnvVarResolver class)
+        assertNotNull("keyIdVariable should not be null", paramMap.get("keyIdVariable"));
+        assertNotNull("secretVariable should not be null", paramMap.get("secretVariable"));
+        assertNotNull("sessionTokenVariable should not be null", paramMap.get("sessionTokenVariable"));
+    }
+}


### PR DESCRIPTION
This change enables the session token environment variable name (`AWS_SESSION_TOKEN`) to be customizable like the accessKey and secretKey.

Closes #90 

## Problem Statement

If someone uses two AWS credentials together and each credential is assuming a role, one credential will override the `AWS_SESSION_TOKEN` environment variable of the other. 

### Testing done

- Tested using unit tests
- Added integration tests

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
