### PR TITLE
[JENKINS-76022] Fix non proxy hosts support

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AWSCredentialsImpl.java
@@ -40,9 +40,11 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -342,6 +344,10 @@ public class AWSCredentialsImpl extends BaseAmazonWebServicesCredentials {
             if (proxy.getUserName() != null) {
                 proxyConfiguration.username(proxy.getUserName());
                 proxyConfiguration.password(Secret.toString(proxy.getSecretPassword()));
+            }
+            List<Pattern> patterns = proxy.getNoProxyHostPatterns();
+            if (patterns != null && !patterns.isEmpty()) {
+                patterns.stream().map(Pattern::pattern).forEach(proxyConfiguration::addNonProxyHost);
             }
             builder.proxyConfiguration(proxyConfiguration.build());
         }


### PR DESCRIPTION
Regression since https://github.com/jenkinsci/aws-credentials-plugin/pull/254. Non Proxy Hosts are not passed to the HTTP Client. If Jenkins proxy is configured to be bypassed for AWS endpoints, the AWS Credentials plugin does not honor it anymore...

### Testing done

* Setup a squid proxy with deny to *.amazonaws.com
* In Jenkins, configure Jenkins Proxy and add `*.amazonaws.com` and `169.254.169.254` to the list of non proxy hosts
* Start Jenkins with `AWS_REGION=us-east-1`
* Configure AWS Credentials with Access Key / Secret Key
* Add a role to assume (a check is done to test the role assumption and it should pass)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed