### PR TITLE
Add documentation for rotating AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@ AWS Credentials Plugin
 - Store Amazon IAM access keys (AWSAccessKeyId and AWSSecretKey) within the Jenkins Credentials API.
 - Also supports IAM Roles and IAM MFA Token.
 
+# Usage
+
+## Rotating AWS Credentials
+
+AWS access keys should be rotated regularly for security best practices.
+
+To rotate credentials stored in Jenkins:
+
+1. Create a new access key in AWS IAM
+2. In Jenkins, open **Manage Jenkins → Credentials**
+3. Locate the existing AWS credential
+4. Click **Update**
+5. Replace the Access Key ID and Secret Access Key
+6. Save the credential
+7. Verify jobs or pipelines using the credential
+
+Pipelines referencing the credential ID do not need to be modified
+after rotation.
+
 # Sample Pipeline Usage
 
 **AWS Credential, this example will automatically setup environment variables AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY**


### PR DESCRIPTION
Adds a section to README explaining how to update and rotate AWS access keys stored in Jenkins credentials. Pipelines using credential IDs continue to work without modification.

<!-- Please describe your pull request here. -->



This PR adds documentation describing how to rotate AWS credentials
stored in Jenkins.

AWS access keys should be rotated regularly as a security best practice.
The README previously did not explain how users can update existing
credentials without breaking pipelines.

The new section explains:

- Creating a new AWS access key in IAM
- Updating the credential in Jenkins
- Ensuring pipelines continue working via credential ID

Fixes #143