### PR TITLE
session token env var customizable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding.java
@@ -57,13 +57,15 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     public static final String DEFAULT_ACCESS_KEY_ID_VARIABLE_NAME = "AWS_ACCESS_KEY_ID";
     private static final String DEFAULT_SECRET_ACCESS_KEY_VARIABLE_NAME = "AWS_SECRET_ACCESS_KEY";
-    private static final String SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
+    private static final String DEFAULT_SESSION_TOKEN_VARIABLE_NAME = "AWS_SESSION_TOKEN";
 
     @NonNull
     private final String accessKeyVariable;
 
     @NonNull
     private final String secretKeyVariable;
+
+    private String sessionTokenVariable;
 
     private String roleArn;
     private String roleSessionName;
@@ -95,6 +97,18 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
     @NonNull
     public String getSecretKeyVariable() {
         return secretKeyVariable;
+    }
+
+    @NonNull
+    public String getSessionTokenVariable() {
+        return (sessionTokenVariable == null || sessionTokenVariable.isBlank())
+                ? DEFAULT_SESSION_TOKEN_VARIABLE_NAME
+                : sessionTokenVariable;
+    }
+
+    @DataBoundSetter
+    public void setSessionTokenVariable(String sessionTokenVariable) {
+        this.sessionTokenVariable = sessionTokenVariable;
     }
 
     @Nullable
@@ -149,7 +163,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
         // If role has been assumed, STS requires AWS_SESSION_TOKEN variable set too.
         if (credentials instanceof AwsSessionCredentials) {
-            m.put(SESSION_TOKEN_VARIABLE_NAME, ((AwsSessionCredentials) credentials).sessionToken());
+            m.put(getSessionTokenVariable(), ((AwsSessionCredentials) credentials).sessionToken());
         }
         return new MultiEnvironment(m);
     }
@@ -175,7 +189,7 @@ public class AmazonWebServicesCredentialsBinding extends MultiBinding<AmazonWebS
 
     @Override
     public Set<String> variables() {
-        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable, SESSION_TOKEN_VARIABLE_NAME));
+        return new HashSet<String>(Arrays.asList(accessKeyVariable, secretKeyVariable, getSessionTokenVariable()));
     }
 
     @Symbol("aws")

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/config-variables.jelly
@@ -30,4 +30,7 @@ THE SOFTWARE.
   <f:entry title="${%Secret Key Variable}" field="secretKeyVariable">
     <f:textbox default="AWS_SECRET_ACCESS_KEY"/>
   </f:entry>
+  <f:entry title="${%Session Token Variable}" field="sessionTokenVariable">
+    <f:textbox default="AWS_SESSION_TOKEN"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBinding/help-sessionTokenVariable.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+<div>
+    Environment variable name for the AWS Session Token, set when the credentials include a session token (e.g. an assumed role). If empty, <code>AWS_SESSION_TOKEN</code> will be used.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBindingTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/awscredentials/AmazonWebServicesCredentialsBindingTest.java
@@ -1,0 +1,39 @@
+package com.cloudbees.jenkins.plugins.awscredentials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AmazonWebServicesCredentialsBindingTest {
+
+    @Test
+    public void sessionTokenVariableDefaultsWhenNotSet() {
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, "credentialsId");
+
+        assertEquals("AWS_SESSION_TOKEN", binding.getSessionTokenVariable());
+        assertTrue(binding.variables().contains("AWS_SESSION_TOKEN"));
+    }
+
+    @Test
+    public void sessionTokenVariableDefaultsWhenBlank() {
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, "credentialsId");
+        binding.setSessionTokenVariable("   ");
+
+        assertEquals("AWS_SESSION_TOKEN", binding.getSessionTokenVariable());
+    }
+
+    @Test
+    public void sessionTokenVariableCanBeCustomized() {
+        AmazonWebServicesCredentialsBinding binding =
+                new AmazonWebServicesCredentialsBinding(null, null, "credentialsId");
+        binding.setSessionTokenVariable("MY_SESSION_TOKEN");
+
+        assertEquals("MY_SESSION_TOKEN", binding.getSessionTokenVariable());
+        assertTrue(binding.variables().contains("MY_SESSION_TOKEN"));
+        assertFalse(binding.variables().contains("AWS_SESSION_TOKEN"));
+    }
+}


### PR DESCRIPTION
Currently the AWS session token is always bound to a fixed AWS_SESSION_TOKEN environment variable when a role is assumed. This adds a sessionTokenVariable option (mirroring the existing accessKeyVariable/secretKeyVariable config) so the session token can be bound to a custom environment variable name, falling back to AWS_SESSION_TOKEN when left blank.

Renamed the private constant to DEFAULT_SESSION_TOKEN_VARIABLE_NAME and added a sessionTokenVariable field with a @DataBoundSetter and a getSessionTokenVariable() getter that falls back to the default when null/blank.
Updated bindSingle and variables() to use getSessionTokenVariable() instead of the hardcoded constant.
Added a "Session Token Variable" field to config-variables.jelly and its help HTML, matching the pattern of the existing key/secret fields.
Testing done
Added AmazonWebServicesCredentialsBindingTest, covering:

getSessionTokenVariable() returns the default AWS_SESSION_TOKEN when the field is unset.
Same default is used when the field is set to a blank string.
A custom name is honored, and variables() reflects the custom name (not the default) when one is configured.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
